### PR TITLE
Hotfix to be able to build with new version of visual studio

### DIFF
--- a/src/pylib.h
+++ b/src/pylib.h
@@ -2,10 +2,7 @@
 // date: 2020
 #pragma once
 
-// hotfix to be able to build with new version of visual studio
-#if defined(_MSC_VER)
-#include <corecrt.h>
-#endif
+#include "os/msvc_error_hotfix.h"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/src/pylib.h
+++ b/src/pylib.h
@@ -2,6 +2,11 @@
 // date: 2020
 #pragma once
 
+// hotfix to be able to build with new version of visual studio
+#if defined(_MSC_VER)
+#include <corecrt.h>
+#endif
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/stl_bind.h>

--- a/src/pylib.h
+++ b/src/pylib.h
@@ -2,7 +2,7 @@
 // date: 2020
 #pragma once
 
-#include "os/compilers.h"
+#include "os/compiler.h"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/src/pylib.h
+++ b/src/pylib.h
@@ -2,7 +2,7 @@
 // date: 2020
 #pragma once
 
-#include "os/msvc_error_hotfix.h"
+#include "os/compilers.h"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>


### PR DESCRIPTION
Workaround for MSVC error described in https://github.com/mazoea/c-image-to-text/pull/554