### PR TITLE
docs: fix clear grammar issues and typos

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Overview
 
-This repository provides interface that wraps functionality from `image_to_text` (written in C++) to be possible to be called from python. This is used for example in `te-server` project. 
+This repository provides an interface that wraps functionality from `image_to_text` (written in C++) to be possible to be called from python. This is used for example in `te-server` project. 
 
 The interface consists of:
 - Source files written in C++ - defines which parts of code will be exposed into python
@@ -11,5 +11,5 @@ The interface consists of:
 Use `PYI2T_BINDIR` environmental variable to point to the directory with the python bindings binaries.
 
 # Exposing symbols from libs (in linux)
-- all function are hidden by default
+- all functions are hidden by default
 - in case you want to expose certain function, add the function name into `libcode.version` file under `global:` functions


### PR DESCRIPTION
## Summary

Mechanical grammar/typo cleanup.

- Readme.md: "provides interface" -> "provides an interface"; "all function are hidden" -> "all functions are hidden"

🤖 Generated with [Claude Code](https://claude.com/claude-code)