### PR TITLE
chore: add gitleaks pre-commit hook + autoupdate revs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v6.0.0
     hooks:
     - id: check-json
     - id: mixed-line-ending
@@ -9,14 +9,18 @@ repos:
     - id: check-added-large-files
       args: ['--maxkb=5000']
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.5.1
+    rev: v2.0.4
     hooks:
     -   id: autopep8
 -   repo: https://github.com/doublify/pre-commit-clang-format
-    rev: f4c4ac5948aff384af2b439bfabb2bdd65d2b3ac
+    rev: 62302476d0da01515660132d76902359bed0f782
     hooks:
     # for windows remove /c//Users//jm//AppData//Roaming//npm//clang-format and keep only *.cmd there!
     -   id: clang-format
         args:
         - --fallback-style=none
         - --style=file
+-   repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+    - id: gitleaks


### PR DESCRIPTION
## Summary
- Adds [gitleaks](https://github.com/gitleaks/gitleaks) v8.30.0 as a pre-commit hook so staged changes are scanned for hardcoded secrets before reaching git history.
- Bumps existing hook revs via `pre-commit autoupdate`.

## Test plan
- [x] `gitleaks detect` on full history — no leaks found
- [x] `pre-commit run` against this commit — all hooks pass
- [ ] CI green on this PR