### PR TITLE
gIssue-1133 / jira-196a/b: expose flowed_grid parser to Python

### DIFF
--- a/pysrc/i2t.py
+++ b/pysrc/i2t.py
@@ -369,6 +369,17 @@ class _i2t(object):
     def ub_parser(self, i2t_doc, i2t_ib_bbox):
         return self._impl.ub_parser(i2t_doc, i2t_ib_bbox)
 
+    def flowed_grid_parser(self, i2t_doc, i2t_ib_bbox):
+        # ADVENT#gIssue-1133 / #jira-196a/b
+        return self._impl.flowed_grid_parser(i2t_doc, i2t_ib_bbox)
+
+    def flowed_grid_classify(self, page):
+        # ADVENT#gIssue-1133 / #jira-196a/b: absent on older i2t builds -> not a flowed-grid page,
+        # so IB falls back to the column parser instead of failing the whole page.
+        if not hasattr(self._impl, "flowed_grid_classify"):
+            return False
+        return self._impl.flowed_grid_classify(page)
+
     # =============
 
     def load_doc(self, js_str):

--- a/src/pylib_forms.cpp
+++ b/src/pylib_forms.cpp
@@ -8,6 +8,8 @@
 
 #include "arguments.h"
 #include "forms/ib/columns_text.h"
+#include "forms/ib/flowed_grid.h"
+#include "forms/ib/flowed_grid_parser.h"
 #include "forms/ib/page_segments_detector.h"
 #include "forms/ib/report.h"
 #include "forms/ib/rough.h"
@@ -250,6 +252,21 @@ namespace maz {
             )
         ;
         
+        // ADVENT#gIssue-1133 / #jira-196a/b: flowed fixed-grid IB parser, routed like `ub_parser`.
+        py::class_<maz::forms::ib::flowed_grid_parser>(m, "flowed_grid_parser")
+            .def(py::init<maz::doc::document&, const bbox_type&>())
+            .def("report", &maz::forms::ib::flowed_grid_parser::report)
+            .def("parse",
+                &maz::forms::ib::flowed_grid_parser::parse,
+                "Parse flowed fixed-grid IB lines",
+                py::return_value_policy::copy
+            )
+        ;
+
+        // ADVENT#gIssue-1133 / #jira-196a/b: read-only flowed fixed-grid IB page test.
+        m.def("flowed_grid_classify", &maz::forms::ib::flowed_grid::classify,
+            "True if the page is a flowed fixed-grid IB page.");
+
         py::class_<maz::forms::ib::report, std::shared_ptr<maz::forms::ib::report>> preport (m, "ib_report");
         preport.def("find_columns", &maz::forms::ib::report::find_columns)
             .def("handle_corner_case", &maz::forms::ib::report::handle_corner_case)


### PR DESCRIPTION
# Fixed by
Expose the flowed fixed-grid IB parser so the TE datamine pipeline can route to it (mirrors the `ub_parser` binding):

- `src/pylib_forms.cpp`: bind `flowed_grid_parser` (ctor + `report()`/`parse()`) and the read-only free function `flowed_grid_classify(page)`.
- `pysrc/i2t.py`: `_i2t` wrapper methods for both.

Consumed by te-server PR #725 (and, as a follow-up, c-image-to-text PR #2071 should bump its `tools/pyi2t` pointer here so its CI builds the binding into published binaries).

Additions only; no change to existing bindings.

# Checklist
- [x] Tested with original PDF input